### PR TITLE
Removes erroneous resolve()

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,8 +151,6 @@ module.exports = {
                 reject(error);
               }
             });
-
-            resolve();
           });
         }).then(function() {
           if(!context.revisionData) {


### PR DESCRIPTION
The extra resolve actually prevents this from activating a deploy. The outer resolve() would be called first before the call to Azure has a chance to complete.

Removing the outer resolve() works as desired.